### PR TITLE
Adapt test to new SummarizedExperiment() requirement

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: glmGamPoi
 Type: Package
 Title: Fit a Gamma-Poisson Generalized Linear Model
-Version: 1.5.3
+Version: 1.5.4
 Authors@R: c(person("Constantin", "Ahlmann-Eltze", email = "artjom31415@googlemail.com", 
                     role = c("aut", "cre"), comment = c(ORCID = "0000-0002-3762-068X")),
              person("Michael", "Love", email="michaelisaiahlove@gmail.com", role = "ctb"))
@@ -40,7 +40,7 @@ Imports:
     matrixStats,
     DelayedArray,
     HDF5Array,
-    SummarizedExperiment,
+    SummarizedExperiment (>= 1.23.2),
     BiocGenerics,
     methods,
     stats,

--- a/tests/testthat/test-glm_gp.R
+++ b/tests/testthat/test-glm_gp.R
@@ -314,14 +314,13 @@ test_that("glm_gp gives error for wrong input data ", {
   expect_error(glm_gp(data = sp_mat))
 })
 
-test_that("glm_gp warns about mismatching col_data rownames ", {
+test_that("glm_gp gives error for mismatching col_data rownames ", {
 
   coldata <- data.frame(condition = c(rep("A", 4), rep("B", 3)), stringsAsFactors = FALSE)
   rownames(coldata) <- paste0("sample_", sample(1:7))
   Y <- matrix(numeric(0), ncol = 7, nrow = 0)
   colnames(Y) <- paste0("sample_", 1:7)
-  fit <- glm_gp(Y, design = ~ condition, col_data = coldata, size_factors = FALSE)
-  expect_equal(c(fit$model_matrix), c(model.matrix(~ condition, coldata)[colnames(Y), ]))
+  expect_error(glm_gp(Y, design = ~ condition, col_data = coldata, size_factors = FALSE))
 })
 
 


### PR DESCRIPTION
Hi Constantin,

Starting with **SummarizedExperiment** 1.23.2, the `SummarizedExperiment()` constructor raises an error if one of the supplied assays has rownames and/or colnames that don't match those inferred from the supplied `rowData` and `colData` arguments. See https://github.com/Bioconductor/SummarizedExperiment/commit/1e1da5b79a035a0f597dedcba42d2cec7a2406c3 and the related discussion [here](https://github.com/Bioconductor/SummarizedExperiment/issues/56).

This change breaks a test in **glmGamPoi** (the "glm_gp warns about mismatching col_data rownames" test). See https://bioconductor.org/checkResults/3.14/bioc-LATEST/glmGamPoi/nebbiolo2-checksrc.html

This PR adapts the test to make it work with the new `SummarizedExperiment()` behavior.

Best,
H.