### PR TITLE
small typo

### DIFF
--- a/R/quasi_gamma_poisson_shrinkage.R
+++ b/R/quasi_gamma_poisson_shrinkage.R
@@ -54,7 +54,7 @@
 #' }
 #'
 #' @examples
-#'  Y <- matrix(rnbinom(n = 300 * 4, mu = 6, size = 1/4.2), nrow = 30, ncol = 4)
+#'  Y <- matrix(rnbinom(n = 300 * 4, mu = 6, size = 1/4.2), nrow = 300, ncol = 4)
 #'  disps <- sapply(seq_len(nrow(Y)), function(idx){
 #'    overdispersion_mle(Y[idx, ])$estimate
 #'  })


### PR DESCRIPTION
Running the previous command would result in:

```
> Y <- matrix(rnbinom(n = 300 * 4, mu = 6, size = 1/4.2), nrow = 30, ncol = 4)
Warning message:
In matrix(rnbinom(n = 300 * 4, mu = 6, size = 1/4.2), nrow = 30,  :
  data length differs from size of matrix: [1200 != 30 x 4]
```