### PR TITLE
feat: add subsample to loc_median_fit

### DIFF
--- a/R/loc_median_fit.R
+++ b/R/loc_median_fit.R
@@ -13,6 +13,8 @@
 #'   `npoints = length(x) * fraction`.
 #' @param weighted a boolean that indicates if a weighted median is calculated.
 #' @param ignore_zeros should the zeros be excluded from the fit
+#' @param sample_fraction fraction of the data to estimate local median on
+#' @param seed control the random sampling of `sample_fraction`
 #'
 #' @details
 #' This function is low-level implementation detail and should usually not be
@@ -27,39 +29,64 @@
 #'
 #'   plot(x, y)
 #'   fit <- loc_median_fit(x, y, fraction = 0.1)
+#'   fit2 <- loc_median_fit(x, y, fraction = 0.1, sample_fraction = 0.75)
 #'   points(x, fit, col = "red")
+#'   points(x, fit, col = "blue")
 #'
 #'
 #' @export
 loc_median_fit <- function(x, y, fraction = 0.1, npoints = max(1, round(length(x) * fraction)),
-                           weighted = TRUE, ignore_zeros = FALSE){
-  # Make sure npoints is valid
-  npoints <- max(1, npoints)
-  npoints <- min(length(x), npoints)
-
-  stopifnot(length(x) == length(y))
-  if(length(x) == 0){
+                           weighted = TRUE, ignore_zeros = FALSE, sample_fraction = 1, seed=42){
+  if (length(x) != length(y)) {
+    stop("x and y must be of the same length.")
+  }
+  if (length(x) == 0) {
     return(numeric(0L))
   }
-  stopifnot(npoints > 0 && npoints <= length(x))
-  ordered_y <- y[order(x)]
-  half_points <- floor(npoints/2)
-  start <- half_points + 1
-  end <- length(x) - half_points
-  weights <- dnorm(seq(-3, 3, length.out = half_points * 2 + 1))
-
-  if(end < start){
-    if(weighted){
-      wm <- matrixStats::weightedMedian(y, w =  dnorm(seq(-3, 3, length.out = length(x))))
-      return(rep(wm, length(x)))
-    }else{
-      return(rep(median(y), length(x)))
-    }
+  if (!is.numeric(sample_fraction) || sample_fraction <= 0 || sample_fraction > 1) {
+    stop("sample_fraction must be a numeric value between 0 and 1.")
+  }
+  if (is.null(npoints)) {
+    npoints <- max(1, round(length(x) * fraction))
+  }
+  if (npoints <= 0 || npoints > length(x)) {
+    stop("npoints must be a positive integer less than or equal to the length of x.")
   }
 
-  res <- rep(NA, length(x))
-  idx <- start
+  if(sample_fraction != 1){
+    set.seed(seed)
+    subset_size <- round(sample_fraction * length(x))
+    sample_indices <- sample(1:length(x), size = subset_size)
+    x_sample <- x[sample_indices]
+    y_sample <- y[sample_indices]
+  } else {
+    x_sample <- x
+    y_sample <- y
+  }
+  
+  # Make sure npoints is valid
+  npoints <- max(1, npoints)
+  npoints <- min(length(x_sample), npoints)
 
+  ordered_indices <- order(x_sample)
+  ordered_y <- y_sample[ordered_indices]
+  half_points <- floor(npoints / 2)
+  start <- half_points + 1
+  end <- length(x_sample) - half_points
+  weights <- dnorm(seq(-3, 3, length.out = half_points * 2 + 1))
+  
+  if(end < start){
+    if(weighted){
+      wm <- matrixStats::weightedMedian(y_sample, w =  dnorm(seq(-3, 3, length.out = length(x_sample))))
+      return(rep(wm, length(x)))
+    }else{
+      return(rep(median(y_sample), length(x)))
+    }
+  }
+  
+  res <- rep(NA, length(x_sample))
+  idx <- start
+  
   while(idx <= end){
     selection <- ordered_y[seq(idx - half_points, idx + half_points)]
     if(ignore_zeros){
@@ -79,12 +106,18 @@ loc_median_fit <- function(x, y, fraction = 0.1, npoints = max(1, round(length(x
     }
     idx <- idx + 1
   }
-
-  # Fill up NA's at the beginning and the end
-  res[seq(1, start - 1)] <- res[start]
-  res[seq(length(x), end+1)] <- res[end]
-
-  res[order(order(x))]
+  
+  # Handle edge cases by extending the closest computed median
+  res[seq_len(start - 1)] <- res[start]
+  res[seq(end + 1, length(x_sample))] <- res[end]
+  
+  if (sample_fraction == 1) {
+    # Reorder the results to match the original x
+    res_ordered <- res
+    res_ordered[ordered_indices] <- res
+    return(res_ordered)
+  } else {
+    interp_func <- approxfun(x_sample[ordered_indices], res, method = "linear", yleft = res[start], yright = res[end])
+    return(interp_func(x))
+  }
 }
-
-

--- a/R/loc_median_fit.R
+++ b/R/loc_median_fit.R
@@ -64,10 +64,10 @@ loc_median_fit <- function(x, y, fraction = 0.1, npoints = max(1, round(length(x
 
   if(end < start){
     if(weighted){
-      wm <- matrixStats::weightedMedian(y, w =  dnorm(seq(-3, 3, length.out = length(x))))
+      wm <- matrixStats::weightedMedian(ordered_y, w =  dnorm(seq(-3, 3, length.out = length(x))))
       return(rep(wm, length(x)))
     }else{
-      return(rep(median(y), length(x)))
+      return(rep(median(ordered_y), length(x)))
     }
   }
 
@@ -95,8 +95,8 @@ loc_median_fit <- function(x, y, fraction = 0.1, npoints = max(1, round(length(x
   }
 
   # Fill up NA's at the beginning and the end
-  res[seq(1, start - 1)] <- res[start]
-  res[seq(length(x), end+1)] <- res[end]
+  res[seq(1, max(1, start - 1))] <- res[start]
+  res[seq(min(length(x), end+1), length(x))] <- res[end]
 
   if (sample_fraction == 1){
     res[order(order(x))]

--- a/R/loc_median_fit.R
+++ b/R/loc_median_fit.R
@@ -1,6 +1,5 @@
 
 
-
 #' Estimate local median fit
 #'
 #' This function fits y based on x through a (weighted) median using
@@ -13,8 +12,8 @@
 #'   `npoints = length(x) * fraction`.
 #' @param weighted a boolean that indicates if a weighted median is calculated.
 #' @param ignore_zeros should the zeros be excluded from the fit
-#' @param sample_fraction fraction of the data to estimate local median on
-#' @param seed control the random sampling of `sample_fraction`
+#' @param sample_fraction use a fraction of the data to estimate the local
+#'   median. Useful for extremely large datasets where the trend is well-sampled
 #'
 #' @details
 #' This function is low-level implementation detail and should usually not be
@@ -31,62 +30,50 @@
 #'   fit <- loc_median_fit(x, y, fraction = 0.1)
 #'   fit2 <- loc_median_fit(x, y, fraction = 0.1, sample_fraction = 0.75)
 #'   points(x, fit, col = "red")
-#'   points(x, fit, col = "blue")
+#'   points(x, fit2, col = "blue")
 #'
 #'
 #' @export
 loc_median_fit <- function(x, y, fraction = 0.1, npoints = max(1, round(length(x) * fraction)),
-                           weighted = TRUE, ignore_zeros = FALSE, sample_fraction = 1, seed=42){
-  if (length(x) != length(y)) {
-    stop("x and y must be of the same length.")
-  }
-  if (length(x) == 0) {
+                           weighted = TRUE, ignore_zeros = FALSE, sample_fraction = 1){
+  # Make sure npoints is valid
+  npoints <- max(1, npoints)
+  npoints <- min(length(x), npoints)
+
+  stopifnot(length(x) == length(y))
+  if(length(x) == 0){
     return(numeric(0L))
   }
+  stopifnot(npoints > 0 && npoints <= length(x))
   if (!is.numeric(sample_fraction) || sample_fraction <= 0 || sample_fraction > 1) {
     stop("sample_fraction must be a numeric value between 0 and 1.")
   }
-  if (is.null(npoints)) {
-    npoints <- max(1, round(length(x) * fraction))
-  }
-  if (npoints <= 0 || npoints > length(x)) {
-    stop("npoints must be a positive integer less than or equal to the length of x.")
-  }
-
   if(sample_fraction != 1){
-    set.seed(seed)
     subset_size <- round(sample_fraction * length(x))
-    sample_indices <- sample(1:length(x), size = subset_size)
-    x_sample <- x[sample_indices]
-    y_sample <- y[sample_indices]
-  } else {
-    x_sample <- x
-    y_sample <- y
+    sample_indices <- sample.int(length(x), size = subset_size)
+    x_orig <- x
+    x <- x[sample_indices]
+    y <- y[sample_indices]
   }
-  
-  # Make sure npoints is valid
-  npoints <- max(1, npoints)
-  npoints <- min(length(x_sample), npoints)
-
-  ordered_indices <- order(x_sample)
-  ordered_y <- y_sample[ordered_indices]
-  half_points <- floor(npoints / 2)
+  ordered_indices <- order(x)
+  ordered_y <- y[ordered_indices]
+  half_points <- floor(npoints/2)
   start <- half_points + 1
-  end <- length(x_sample) - half_points
+  end <- length(x) - half_points
   weights <- dnorm(seq(-3, 3, length.out = half_points * 2 + 1))
-  
+
   if(end < start){
     if(weighted){
-      wm <- matrixStats::weightedMedian(y_sample, w =  dnorm(seq(-3, 3, length.out = length(x_sample))))
+      wm <- matrixStats::weightedMedian(y, w =  dnorm(seq(-3, 3, length.out = length(x))))
       return(rep(wm, length(x)))
     }else{
-      return(rep(median(y_sample), length(x)))
+      return(rep(median(y), length(x)))
     }
   }
-  
-  res <- rep(NA, length(x_sample))
+
+  res <- rep(NA, length(x))
   idx <- start
-  
+
   while(idx <= end){
     selection <- ordered_y[seq(idx - half_points, idx + half_points)]
     if(ignore_zeros){
@@ -106,18 +93,15 @@ loc_median_fit <- function(x, y, fraction = 0.1, npoints = max(1, round(length(x
     }
     idx <- idx + 1
   }
-  
-  # Handle edge cases by extending the closest computed median
-  res[seq_len(start - 1)] <- res[start]
-  res[seq(end + 1, length(x_sample))] <- res[end]
-  
-  if (sample_fraction == 1) {
-    # Reorder the results to match the original x
-    res_ordered <- res
-    res_ordered[ordered_indices] <- res
-    return(res_ordered)
+
+  # Fill up NA's at the beginning and the end
+  res[seq(1, start - 1)] <- res[start]
+  res[seq(length(x), end+1)] <- res[end]
+
+  if (sample_fraction == 1){
+    res[order(order(x))]
   } else {
-    interp_func <- approxfun(x_sample[ordered_indices], res, method = "linear", yleft = res[start], yright = res[end])
-    return(interp_func(x))
+    interp_func <- approxfun(x[ordered_indices], res, method = "linear", yleft = res[start], yright = res[end])
+    interp_func(x_orig)
   }
 }


### PR DESCRIPTION
I've found that the `loc_median_fit` can really slow things down on larger datasets with many "genes" (i.e. >10^6 rows) during the over-dispersion shrinkage step. The idea here is we can subsample the number of "genes" used when determining the dispersion trend to speed the calculation up. There should be plenty of samples to estimate the median trend without taking a huge hit in accuracy.

```
x <- runif(n = 100000, max = 4)
y <- rpois(n = 100000, lambda = x * 10)
bench::mark(
    loc_median_fit(x, y, npoints=100),
    loc_median_fit(x, y, npoints=100, sample_fraction = 0.1),
    check = FALSE
)

>  expression                                                      min   median `itr/sec` ...
> 1 loc_median_fit(x, y, npoints = 100)                         765.8ms  765.8ms      1.31
> 2 loc_median_fit(x, y, npoints = 100, sample_fraction = 0.1)   66.4ms   67.4ms     14.1
```

I'd definitely consider this a "rough" implementation. There's probably better ways to factor the logic. Just wanted to get something off the ground to start the conversation!