### PR TITLE
Resync with recent developments in SparseArray/DelayedArray packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: glmGamPoi
 Type: Package
 Title: Fit a Gamma-Poisson Generalized Linear Model
-Version: 1.17.3
+Version: 1.17.4
 Authors@R: c(person("Constantin", "Ahlmann-Eltze", email = "artjom31415@googlemail.com", 
                     role = c("aut", "cre"), comment = c(ORCID = "0000-0002-3762-068X")),
              person("Nathan", "Lubock", email="lubock.nathan@gmail.com", role = "ctb", 
@@ -43,6 +43,7 @@ Imports:
     DelayedMatrixStats,
     matrixStats,
     MatrixGenerics,
+    SparseArray (>= 1.5.21),
     DelayedArray,
     HDF5Array,
     SummarizedExperiment,

--- a/R/estimate_size_factors.R
+++ b/R/estimate_size_factors.R
@@ -91,7 +91,7 @@ combine_size_factors_and_offset <- function(offset, size_factors, Y, verbose = F
     stopifnot(length(offset) == 1 || length(offset) == n_samples)
     zero_offset <- all(offset == 0)
     if(make_offset_hdf5_mat){
-      offset_matrix <- DelayedArray::DelayedArray(DelayedArray::SparseArraySeed(c(n_genes, n_samples)))
+      offset_matrix <- DelayedArray::DelayedArray(SparseArray::COO_SparseArray(c(n_genes, n_samples)))
       offset_matrix <- add_vector_to_each_row(offset_matrix, offset)
     }else{
       offset_matrix <- matrix(offset, nrow=n_genes, ncol = n_samples, byrow = TRUE)


### PR DESCRIPTION
Hi @const-ae,

This PR fixes some breakage caused by recent changes to the **SparseArray** and **DelayedArray** packages. In particular, starting with **DelayedArray** >= 0.31.5, SparseArraySeed objects are deprecated in favor of COO_SparseArray objects from the **SparseArray** package.

Note that this PR requires **SparseArray** >= 1.5.21 which is available on GitHub [here](https://github.com/Bioconductor/SparseArray) but will only propagate to the Bioconductor package repositories in the next 48 hrs or so.

Let me know if you have questions.

Best,
H.