### PR TITLE
Allow DelayedArray offset when combining size factors and offset

### DIFF
--- a/R/estimate_size_factors.R
+++ b/R/estimate_size_factors.R
@@ -83,7 +83,7 @@ combine_size_factors_and_offset <- function(offset, size_factors, Y, verbose = F
   if(is.matrix(offset)){
     stopifnot(dim(offset) == c(n_genes, n_samples))
     offset_matrix <- offset
-  }else if(is(offset, "HDF5Matrix")){
+  }else if(is(offset, "HDF5Matrix") || is(offset, "DelayedArray")){
     stopifnot(dim(offset) == c(n_genes, n_samples))
     stopifnot(make_offset_hdf5_mat)
     offset_matrix <- offset


### PR DESCRIPTION
This PR addresses the issue when `offset` is a `DelayedArray` object, and the check enters `else` and get stopped at Line 91.

https://github.com/const-ae/glmGamPoi/blob/e8799cbd0efed02a49e43adf13fe98f0963d5374/R/estimate_size_factors.R#L83-L91

My use case is following DESeq2's LRT workflow with a sparse matrix input and `on_disk = TRUE`. We use `glmGamPoi::glm_gp` to perform fitting and then `glmGamPoi::test_de` to test for DE. 

While running `glm_gp`, the `offset_matrix` is converted into a `DelayedArray` object at one stage. 
While running `test_de`, it calls `glm_gp` again when fitting the reduced model. At this point, the `fit$Offset` is a `DelayedArray` object and will failed with following error message

``` r
Error in combine_size_factors_and_offset(offset, size_factors, Y, verbose = verbose): 
  length(offset) == 1 || length(offset) == n_samples is not TRUE
```