### PR TITLE
Add (1e-6)*I ridge to fisher information for consistency w/ padded d,d^2

### DIFF
--- a/src/overdispersion.cpp
+++ b/src/overdispersion.cpp
@@ -75,14 +75,12 @@ double conventional_loglikelihood_fast(NumericVector y, NumericVector mu, double
   if(do_cr_adj){
     arma::vec w_diag = 1.0 / (1.0 / mu + theta);
     arma::mat b = model_matrix.t() * (model_matrix.each_col() % w_diag);
-    // cr_term = -0.5 * log(det(b)) * cr_correction_factor;
-    arma::mat L, U, P;
-    arma::lu(L, U, P, b);
-    double ld = sum(log(arma::diagvec(L)));
-    arma::vec u_diag = arma::diagvec(U);
-    for(double e : u_diag){
-      ld += e < 1e-50 ? log(1e-50) : log(e);
-    }
+
+    // pair the objective w/ the small ridge pad=1.0e-6 that is used in the score/hessian
+    // (conventional_score_function_fast(), conventional_deriv_score_function_fast())
+    b.diag() += 1e-6;
+
+    double ld = arma::log_det_sympd(b);
     cr_term = -0.5 * ld * cr_correction_factor;
   }
   double theta_neg1 = R_pow_di(theta, -1);

--- a/tests/testthat/test-overdispersion.R
+++ b/tests/testthat/test-overdispersion.R
@@ -92,6 +92,31 @@ test_that("C++ implementation of score and score_deriv match", {
 })
 
 
+test_that("Cox-Reid derivatives match objective for ill-conditioned design", {
+  y <- rep(20, 8)
+  mu <- rep(20, 8)
+  modelMatrix <- cbind(1, rep(c(0, 1, 2, 4), each = 2) * 1e-6)
+  logTheta <- log(0.2)
+
+  crObjective <- function(value){
+    conventional_loglikelihood_fast(y, mu, value, modelMatrix, do_cr_adj = TRUE) -
+      conventional_loglikelihood_fast(y, mu, value, modelMatrix, do_cr_adj = FALSE)
+  }
+  crScore <- conventional_score_function_fast(y, mu, logTheta, modelMatrix, do_cr_adj = TRUE) -
+    conventional_score_function_fast(y, mu, logTheta, modelMatrix, do_cr_adj = FALSE)
+  crHessian <- conventional_deriv_score_function_fast(y, mu, logTheta, modelMatrix, do_cr_adj = TRUE) -
+    conventional_deriv_score_function_fast(y, mu, logTheta, modelMatrix, do_cr_adj = FALSE)
+
+  stepSize <- 1e-3
+  objectiveValues <- vapply(logTheta + c(-stepSize, 0, stepSize), crObjective, numeric(1))
+  numericScore <- (objectiveValues[3] - objectiveValues[1]) / (2 * stepSize)
+  numericHessian <- (objectiveValues[3] - 2 * objectiveValues[2] + objectiveValues[1]) / stepSize^2
+
+  expect_equal(crScore, numericScore, tolerance = 1e-6)
+  expect_equal(crHessian, numericHessian, tolerance = 1e-6)
+})
+
+
 
 
 test_that("Estimation methods can handle under-dispersion", {
@@ -340,7 +365,6 @@ test_that("global overdispersion estimation works", {
   expect_equal(res3, res2)
 
 })
-
 
 
 


### PR DESCRIPTION
*Problem*: Discrepancy between numerics in the cox-reid log-likelihood and its derivatives. The log-likelihood applies `ld += e < 1e-50 ? log(1e-50) : log(e);` for stabilization, but the score/hessian fix a ridge `+= 1e-6*I`. This can affect convergence under tight tolerances since descent directions do not correspond to the exact objective being optimized.

*Proposed Fix*: added the same padding to `conventional_loglikelihood_fast()` so that it is consistent with the score and deriv_score functions.

I also added a small test that uses a full-rank but poorly scaled design and checks that the score and curvature match the objective.